### PR TITLE
Handle infinite loop edge case in block filling

### DIFF
--- a/src/main/java/vazkii/pillar/StructureGenerator.java
+++ b/src/main/java/vazkii/pillar/StructureGenerator.java
@@ -151,7 +151,7 @@ public final class StructureGenerator {
                                 world.setBlockState(checkPos, newState);
                             } else break;
 
-                            if (checkPos.getY() == 0) break;
+                            if (checkPos.getY() <= 0) break;
 
                             k--;
                         }


### PR DESCRIPTION
Single line change to fix a possible infinite loop when the structure's position is y=0. Discovered when a Pillar structure was generated inside of an edge of a Buildcraft oil well (sets all adjacent blocks to air down to bedrock).
The infinite loop is also reproducible by generating a superflat world with only a bedrock layer at y=0, and having any Pillar structure with a `filling` block specified.